### PR TITLE
Fix: Add -z flag support and pruned-variants file output for -prob mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Writing new haplotype file
 
 
 #### Given Probabilities
-To prune variants using known or given probabilities, add a column to the legend file (`-l`) named "prob". A random number between 0 and 1 is generated for each variant, and if the number is greater than the probability, the variant is removed from the data.
+To prune variants using known or given probabilities, add a column to the legend file (`-l`) named "prob". A random number between 0 and 1 is generated for each variant, and if the number is greater than the probability, the variant is removed from the data. When using the `-z` flag, monomorphic and pruned variants are removed from the output haplotype file, and a pruned-variants file is created.
 
 ```text
 $ python3 -m raresim sim \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "raresim"
-version = "3.0.1"
+version = "3.0.2"
 description = "A python interface for scalable rare-variant simulations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/raresim/engine/pruners.py
+++ b/raresim/engine/pruners.py
@@ -357,6 +357,8 @@ class ProbabilisticPruner(Pruner):
 
         :return: None
         """
+        rows_to_keep = []
+        
         for row_index in range(self.__matrix.num_rows()):
             row = self.__matrix.get_row_raw(row_index)
             for col_index in row:
@@ -366,3 +368,21 @@ class ProbabilisticPruner(Pruner):
                     continue
                 elif flip > float(legend_val):
                     self.__matrix.remove(row_index, col_index)
+            
+            if self.__matrix.row_num(row_index) > 0:
+                rows_to_keep.append(row_index)
+        
+        trimmed_vars_file = open(
+            f'{self.__config.args.output_legend if self.__config.args.output_legend is not None else self.__config.args.input_legend}-pruned-variants', 'w')
+        trimmed_vars_file.write("\t".join(self.__legend.get_header()) + '\n')
+        for row in range(self.__matrix.num_rows()):
+            if row not in rows_to_keep:
+                trimmed_vars_file.write("\t".join([y for x, y in self.__legend[row].items()]) + '\n')
+        
+        trimmed_vars_file.close()
+        
+        if self.__config.remove_zeroed_rows:
+            rows_to_remove = [x for x in range(self.__matrix.num_rows()) if x not in rows_to_keep]
+            for rowId in rows_to_remove[::-1]:
+                self.__legend.remove_row(rowId)
+                self.__matrix.remove_row(rowId)

--- a/tests/test_real_data_integration.py
+++ b/tests/test_real_data_integration.py
@@ -187,6 +187,80 @@ class TestRealDataWorkflows(unittest.TestCase):
         self.assertEqual(output_matrix.num_rows(), 31, "Should maintain all 31 rows")
         self.assertEqual(output_matrix.num_cols(), 20, "Should maintain all 20 columns")
     
+    def test_probabilistic_pruning_with_z_flag(self):
+        """Test probabilistic pruning with -z flag creates pruned-variants file and removes zeroed rows"""
+        random.seed(42)
+        
+        haps_file = os.path.join(self.data_dir, 'ProbExample.haps')
+        legend_file = os.path.join(self.data_dir, 'ProbExample.probs.legend')
+        output_hap = os.path.join(self.temp_dir, 'prob_z_output.haps.gz')
+        output_legend = os.path.join(self.temp_dir, 'prob_z_output.legend')
+        
+        reader = SparseMatrixReader()
+        original_matrix = reader.loadSparseMatrix(haps_file)
+        original_legend = LegendReaderWriter.load_legend(legend_file)
+        
+        self.assertEqual(original_matrix.num_rows(), 31)
+        
+        args = Namespace(
+            sparse_matrix=haps_file,
+            input_legend=legend_file,
+            output_legend=output_legend,
+            output_hap=output_hap,
+            exp_bins=None,
+            exp_fun_bins=None,
+            exp_syn_bins=None,
+            fun_bins_only=None,
+            syn_bins_only=None,
+            prob=True,
+            z=True,
+            remove_zeroed_rows=True,
+            small_sample=True,
+            keep_protected=False,
+            activation_threshold=10,
+            stop_threshold=20,
+            verbose=False
+        )
+        
+        config = RunConfig(args)
+        self.assertEqual(config.run_type, 'probabilistic')
+        self.assertTrue(config.remove_zeroed_rows)
+        
+        runner = DefaultRunner(config)
+        runner.run()
+        
+        # Verify output files were created
+        self.assertTrue(os.path.exists(output_hap), "Output haps file must be created")
+        self.assertTrue(os.path.exists(output_legend), "Output legend file must be created")
+        
+        # Verify pruned-variants file was created
+        pruned_variants_file = f'{output_legend}-pruned-variants'
+        self.assertTrue(os.path.exists(pruned_variants_file), 
+                       "Pruned-variants file must be created with -prob and -z flags")
+        
+        # Load output and verify
+        output_matrix = reader.loadSparseMatrix(output_hap)
+        output_legend = LegendReaderWriter.load_legend(output_legend)
+        
+        # With -z flag, zeroed rows should be removed
+        self.assertLess(output_matrix.num_rows(), original_matrix.num_rows(),
+                       "With -z flag, some rows should be removed")
+        
+        # Verify no zeroed rows remain
+        for i in range(output_matrix.num_rows()):
+            self.assertGreater(output_matrix.row_num(i), 0,
+                             f"Row {i} should not be zero after -z flag")
+        
+        # Verify legend and matrix match
+        self.assertEqual(output_legend.row_count(), output_matrix.num_rows(),
+                        "Legend and matrix row counts must match")
+        
+        # Verify pruned-variants file has header and content
+        with open(pruned_variants_file, 'r') as f:
+            lines = f.readlines()
+            self.assertGreater(len(lines), 1, "Pruned-variants file should have header and data")
+            self.assertIn('id', lines[0], "First line should be header")
+    
     def test_standard_pruning_complete_workflow(self):
         """Test complete standard pruning workflow - NO exception catching"""
         # Set random seed for deterministic results


### PR DESCRIPTION
- ProbabilisticPruner now tracks pruned/zeroed variants
- Creates .legend-pruned-variants file when using -prob flag
- Supports -z flag to remove zeroed rows from output
- Updated README to document the fixed behavior
- Added comprehensive test for -prob with -z flag
- All existing tests pass without regression

Fixes issue reported by stakeholders where -prob flag did not output pruned-variants file or support -z flag for removing zeroed rows.